### PR TITLE
Hackish bug fix

### DIFF
--- a/contrib/tools/workflowcheck/determinism/checker.go
+++ b/contrib/tools/workflowcheck/determinism/checker.go
@@ -424,7 +424,9 @@ func (c *collector) applyFacts() PackageNonDeterminisms {
 	}
 
 	// Export package fact
-	c.pass.ExportPackageFact(&p)
+	if len(c.pass.Files) != 0 {
+		c.pass.ExportPackageFact(&p)
+	}
 	return p
 }
 


### PR DESCRIPTION
It calls that function when there is 0 files and crash if run with debug or always on golangci-lint.

I create upstream bugticket from this but this fixes the issue(golden_test)